### PR TITLE
Remove unused steps from Release CI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -17,8 +17,10 @@ jobs:
         python-version: 3.8
     - name : Install Prerequisites
       run : |
+        sudo apt-get install software-properties-common
+        sudo apt-add-repository universe
+        sudo apt-get update
         sudo apt-get install gcc libpq-dev -y
-        sudo apt-get install python-dev  python-pip -y
         sudo apt-get install python3-dev python3-pip python3-venv python3-wheel -y
         pip3 install wheel
     - name: Build sdist and bdist_wheel


### PR DESCRIPTION
Python 2 packages are not available by default in Ubuntu 20.04 containers. This PR removes unused Python 2 installation steps which were breaking the Release CI 